### PR TITLE
fix(runtime)!: page generation issues

### DIFF
--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -74,7 +74,7 @@ exports.createPages = async ({ graphql, actions }) => {
   products.forEach(product => {
     createPage({
       path: `/${product.node.category.name.toLowerCase()}/${
-        product.node.name.split(" ")[0]
+        product.node.name.split(" ")[0].toLowerCase()
       }`,
       component: require.resolve("./src/templates/ProductDetail.js"),
       context: {


### PR DESCRIPTION
Hi!

I was in a session with one of my mentees that bought your Udemy course and we faced some critical issues that affect page generation. There are others (that I haven't been able to dive into) that can be related to the dependency version (this course uses Gatsby v2 while now they are about to ship the 4 so I won't give them much importance.

The problem was that some pages were being generated without serializing the URLs so, instead of `/shirts/aloe`, the generated page was `/shirts/Aloe`, (and so on for the rest of categories/products). So all the references to that slug (from the product page for example) fail because of that.

The purpose of this PR is to fix that bug.

Don't hesitate to contact me for further details!

Thanks!